### PR TITLE
Upgrade bundler to 4.0.20 in Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -285,4 +285,4 @@ DEPENDENCIES
   github-pages
 
 BUNDLED WITH
-   2.3.4
+  4.0.20


### PR DESCRIPTION
## Summary

The lockfile still declared bundler `2.3.4`, the version that generated it years ago. This updates `BUNDLED WITH` to `4.0.20`, the current release.

```diff
 BUNDLED WITH
-   2.3.4
+  4.0.20
```

That is the entire diff. No gem versions change.

The lockfile was updated in place rather than regenerated from scratch, which preserves the existing format: the `PLATFORMS` entry stays the platform-independent `ruby`, and no `CHECKSUMS` section is introduced.

## Two things to know about bundler 4

- Contributors running an older bundler will be prompted to install 4.x when they run `bundle`.
- Regenerating this lockfile from scratch under bundler 4, rather than updating it in place, rewrites it into the newer format with per-platform gem entries and a `CHECKSUMS` section. Keep using `bundle lock --update` to avoid that churn.

## Verification

- `bundle install` succeeds under 4.0.20
- `jekyll build` succeeds
- `bundler-audit` reports no vulnerabilities
- Rendered site is byte-identical to the current build

I also confirmed bundler 2.7.2 produces the same 2-line change and an identical build, so reverting to the 2.x line later is straightforward if bundler 4 causes friction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012FQZdbnNMj7Xp5aCBBz1WH

---
_Generated by [Claude Code](https://claude.ai/code/session_012FQZdbnNMj7Xp5aCBBz1WH)_